### PR TITLE
feat: add open edx test issuer for lc wallet integration

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -28,6 +28,11 @@
       "name":"Digital Credentials Consortium Test Issuer",
        "location":"Ancaster, ON, Canada",
        "url":"https://www.dcconsortium.org/"
+    },
+    "did:key:z6MkkePoGJV8CQJJULSHHUEv71okD9PsrqXnZpNQuoUfb3id":{
+      "name":"Open edX Test Issuer (RaccoonGang)",
+      "location":"Cambridge, MA, USA",
+      "url":"https://openedx.org/"
     }
   }
 }


### PR DESCRIPTION
We want to add Open edX testing Issuer DID into the sandbox registry, so we can proceed with integration between LC Wallet and Open edX system.

This issuer identity is used only for development/testing purposes. After the integration with LC Wallet is done, production Issuer DID will be pushed to the [Community registry](https://github.com/digitalcredentials/community-registry).