### PR TITLE
Update registry.json

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,11 +1,16 @@
 {
   "meta": {
     "created": "2022-10-27T17:57:31+00:00",
-    "updated": "2025-05-08T13:07:01+00:00"
+    "updated": "2025-05-09T14:37:07+00:00"
   },   
   "registry": {
     "did:web:digitalcredentials.github.io:vc-test-fixtures:dids:legacy": {
       "name": "DCC did:web for testing",
+      "location": "Cambridge, MA, USA",
+      "url": "https://digitalcredentials.mit.edu"
+    },
+    "did:key:z6Mki7DqKQswPsjqMVhP4W3n2ABFb5wBegZC5erEVg5qcgEw": {
+      "name": "DCC did:key for testing a did in legacy and oidf",
       "location": "Cambridge, MA, USA",
       "url": "https://digitalcredentials.mit.edu"
     },


### PR DESCRIPTION
add did:key that is also in the test.registry.dcconsortium.org OIDF registry, to be used for testing cases where a VC has been signed by a DID that appears in both the OIDF and legacy (i.e, this sandbox) registries