### PR TITLE
Add openedx con demo issuer

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "created": "2022-10-27T17:57:31+00:00",
-    "updated": "2025-05-09T18:17:57+00:00"
+    "updated": "2025-06-29T11:33:38+00:00"
   },   
   "registry": {
     "did:web:digitalcredentials.github.io:vc-test-fixtures:dids:legacy": {


### PR DESCRIPTION
@jchartrand I plan to present a demo for integration with LC Wallet on Open edX CON2025 and want to add a demo issuer to the sandbox-registry.
