### PR TITLE
Add How to Change the World test issuer

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "created": "2022-10-27T17:57:31+00:00",
-    "updated": "2026-03-25T00:00:00+00:00"
+    "updated": "2026-04-23T00:00:00+00:00"
   },
   "registry": {
     "did:web:digitalcredentials.github.io:vc-test-fixtures:dids:legacy": {
@@ -185,6 +185,11 @@
       "name": "FBR (Test Issuer)",
       "location": "Islamabad, Pakistan",
       "url": "https://fbrlms.edly.io/"
+    },
+    "did:key:z6MkvxDfCCScZv7jEMYu3QgzwJasj8A4dReE3Q9tGg1BsaNe": {
+      "name": "How to Change the World",
+      "location": "Global",
+      "url": "https://how-to-change-the-world.org"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a sandbox registry entry for the **How to Change the World** Open Badges 3.0 issuer.

- **DID:** `did:key:z6MkvxDfCCScZv7jEMYu3QgzwJasj8A4dReE3Q9tGg1BsaNe`
- **Name:** How to Change the World
- **Location:** Global
- **URL:** https://how-to-change-the-world.org

This is needed so credentials signed by this key are recognized as a known sandbox issuer in DCC tooling (Verifier Plus / LCW) during OB 3.0 integration testing.