### PR TITLE
Add did:web:proof.recworks.io (RecWorks Credentials)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "created": "2022-10-27T17:57:31+00:00",
-    "updated": "2026-03-25T00:00:00+00:00"
+    "updated": "2026-06-05T00:00:00+00:00"
   },
   "registry": {
     "did:web:digitalcredentials.github.io:vc-test-fixtures:dids:legacy": {
@@ -196,4 +196,9 @@
       "url": "https://test.digitalbadges.scot"
     }
   }
+},
+"did:web:proof.recworks.io": {
+  "name": "RecWorks Credentials",
+  "location": "Chapel Hill, NC, USA",
+  "url": "https://proof.recworks.io"
 }

--- a/registry.json
+++ b/registry.json
@@ -194,11 +194,11 @@
       "name": "Scottish Digital Badges (Test Issuer)",
       "location": "Scotland",
       "url": "https://test.digitalbadges.scot"
+    },
+    "did:web:proof.recworks.io": {
+      "name": "RecWorks Credentials",
+      "location": "Chapel Hill, NC, USA",
+      "url": "https://proof.recworks.io"
     }
   }
-},
-"did:web:proof.recworks.io": {
-  "name": "RecWorks Credentials",
-  "location": "Chapel Hill, NC, USA",
-  "url": "https://proof.recworks.io"
 }


### PR DESCRIPTION
RecWorks Credentials is a digital credentialing platform issuing OBI 3.0 badges. Adding did:web:proof.recworks.io for sandbox testing ahead of production registration via Credential Engine.