### PR TITLE
Add CredTrail sandbox issuer

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -202,7 +202,7 @@
     },
     "did:web:credtrail.org": {
       "name": "CredTrail Sandbox Issuer",
-      "location": "United States",
+      "location": "Independence, OH, USA",
       "url": "https://credtrail.org"
     }
   }

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "created": "2022-10-27T17:57:31+00:00",
-    "updated": "2026-06-05T00:00:00+00:00"
+    "updated": "2026-06-17T00:00:00+00:00"
   },
   "registry": {
     "did:web:digitalcredentials.github.io:vc-test-fixtures:dids:legacy": {
@@ -199,6 +199,11 @@
       "name": "RecWorks Credentials",
       "location": "Chapel Hill, NC, USA",
       "url": "https://proof.recworks.io"
+    },
+    "did:web:credtrail.org": {
+      "name": "CredTrail Sandbox Issuer",
+      "location": "United States",
+      "url": "https://credtrail.org"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds CredTrail's public `did:web:credtrail.org` identifier to the sandbox issuer registry for testing purposes.

## Notes

- Uses only public CredTrail metadata.
- Keeps the entry clearly scoped as a sandbox issuer.
- Updates the registry metadata timestamp to 2026-06-17.

## Validation

- `jq empty registry.json`
- Confirmed `https://credtrail.org/.well-known/did.json` resolves with `id: "did:web:credtrail.org"` and `did:web:credtrail.org#key-1` in `assertionMethod`.
